### PR TITLE
Fixed module name and import example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ npm install youtube.get-video-info --save
 ```
 then
 ```
-var yt = require('./youtube.get-video.info');
+var yt = require('youtube.get-video-info');
 yt.retrieve('ml-v1bgMJDQ', function(err, res) {
   if (err) throw err;
   console.log(res);

--- a/test.js
+++ b/test.js
@@ -1,4 +1,4 @@
-var yt = require('./youtube.get-video.info');
+var yt = require('youtube.get-video-info');
 
 function cb(err, res) {
   if (err) console.log('ERROR:', err);


### PR DESCRIPTION
Fixed a typo in the name. 

Also in response to your comment on [my last pull request](https://github.com/pste/youtube.get-video-info/pull/1), the `./` prefix only works if you have the file downloaded in a local directory. That's likely why it works in your tests when you run `test.js` (because `youtube.get-video.info.js` is in the same directory). When you install it via npm though, it downloads to your `node_modules` directory, so you can't import it locally. You need to use the full package name, and node will handle importing the right file based on your `package.json`.

See the official [npm documentation](https://docs.npmjs.com/getting-started/installing-npm-packages-locally).